### PR TITLE
Shows back button in sim screen

### DIFF
--- a/web/src/styles/sim.css
+++ b/web/src/styles/sim.css
@@ -8,7 +8,8 @@
   position: absolute;
   top: 24px;
   left: 24px;
-  z-index: 2;
+  z-index: 1000;
+  color: #000;
 }
 
 .sim-toolbar {


### PR DESCRIPTION
# Pull request format

## Title of Issue to be fixed:

Feature/back-button-not-shown

## Description of changes:

Pushes the back button in front of the background, and changes its color to black so it doesn't get lost.

## People for Review:

Aidan Daly